### PR TITLE
Add Cyclad provider for Nancras

### DIFF
--- a/custom_components/waste_collection_schedule/sources.json
+++ b/custom_components/waste_collection_schedule/sources.json
@@ -4621,6 +4621,14 @@
         "city": "Villenave-d'Ornon"
       },
       "id": "opendata_bordeauxmetropole_fr"
+    },
+    {
+      "title": "Nancras",
+      "module": "cyclad_org",
+      "default_params": {
+        "city_id": 254
+      },
+      "id": "cyclad_org"
     }
   ],
   "Generic": [

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/cyclad_org.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/cyclad_org.py
@@ -1,0 +1,58 @@
+import requests
+from datetime import datetime
+from waste_collection_schedule import Collection  # type: ignore[attr-defined]
+
+TITLE = "Cyclad"
+DESCRIPTION = "Source for cyclad.org waste collection schedules"
+URL = "https://cyclad.org/"
+COUNTRY = "fr"
+
+TEST_CASES = {
+    "Nancras": {"city_id": 254},
+}
+
+ICON_MAP = {
+    "Emballage": "mdi:recycle",
+    "Ordures ménagères": "mdi:trash-can",
+    "biodechets": "mdi:leaf",
+}
+
+API_URL = "https://cyclad.org/wp/wp-admin/admin-ajax.php"
+
+class Source:
+    def __init__(self, city_id: int):
+        self._city_id = city_id
+
+    def fetch(self):
+        response = requests.post(
+            API_URL,
+            data={"action": "ajax_calendar_autocomplete", "post_id": self._city_id},
+        )
+        response.raise_for_status()
+        data = response.json()
+        if not data:
+            return []
+        schedules = data[0].get("dates", {})
+        entries = []
+        for waste_type, dates in schedules.items():
+            if not dates:
+                continue
+            if isinstance(dates, dict):
+                date_list = dates.values()
+            elif isinstance(dates, list):
+                date_list = dates
+            else:
+                continue
+            for date_str in date_list:
+                try:
+                    dt = datetime.strptime(date_str, "%d/%m/%Y").date()
+                except ValueError:
+                    continue
+                entries.append(
+                    Collection(
+                        date=dt,
+                        t=waste_type,
+                        icon=ICON_MAP.get(waste_type),
+                    )
+                )
+        return entries

--- a/doc/source/cyclad_org.md
+++ b/doc/source/cyclad_org.md
@@ -1,0 +1,31 @@
+# Cyclad — provider for waste management schedules
+
+Support for schedules provided by [Cyclad](https://cyclad.org/).
+
+The list of available communes can be retrieved from <https://cyclad.org/wp-json/vernalis/v1/communes>.
+The value of `ID` for your commune must be used as `city_id` in the configuration.
+
+## Configuration via configuration.yaml
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cyclad_org
+      args:
+        city_id: 254
+```
+
+### Configuration variables
+
+**city_id**
+*(integer) (required)* ID of your commune from the [Cyclad communes list](https://cyclad.org/wp-json/vernalis/v1/communes).
+
+## Example
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: cyclad_org
+      args:
+        city_id: 254
+```


### PR DESCRIPTION
## Summary
- add new Cyclad provider module to fetch schedules from cyclad.org
- document configuration for Cyclad
- register Nancras city in `sources.json`

## Testing
- `pip install pyyaml`
- `pip install requests`
- `pip install jinja2`
- `pip install icalevents`
- `pip install beautifulsoup4`
- `pip install pypdf`
- `pip install pycryptodome`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbeadb934832d8e698aefd4555399